### PR TITLE
Rock Collision Bugfix

### DIFF
--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -39,7 +39,7 @@ Physics2DSettings:
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
   m_AutoSimulation: 1
-  m_QueriesHitTriggers: 1
+  m_QueriesHitTriggers: 0
   m_QueriesStartInColliders: 0
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 0


### PR DESCRIPTION
- Raycasts considered triggers as potential collisions.
- Modification of a project setting simply removed this behavior (triggers still work since no raycasts are needed for them).